### PR TITLE
Fix port variable and book service update

### DIFF
--- a/apps/auth/src/main.ts
+++ b/apps/auth/src/main.ts
@@ -5,6 +5,6 @@ import { Logger } from 'nestjs-pino';
 async function bootstrap() {
   const app = await NestFactory.create(AuthModule);
   app.useLogger(app.get(Logger));
-  await app.listen(process.env.port ?? 3001);
+  await app.listen(process.env.PORT ?? 3001);
 }
 bootstrap();

--- a/apps/book/src/book.service.ts
+++ b/apps/book/src/book.service.ts
@@ -24,7 +24,7 @@ export class BookService {
   }
 
   update(_id: string, updateBookDto: UpdateBookDto) {
-    return this.bookRepository.findOneAndUpdate({_id , }, {$set : updateBookDto})
+    return this.bookRepository.findOneAndUpdate({ _id }, { $set: updateBookDto });
   }
 
   remove(_id: string) {

--- a/apps/book/src/main.ts
+++ b/apps/book/src/main.ts
@@ -5,6 +5,6 @@ import { Logger } from 'nestjs-pino';
 async function bootstrap() {
   const app = await NestFactory.create(BookModule);
   app.useLogger(app.get(Logger));
-  await app.listen(process.env.port ?? 3000);
+  await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
## Summary
- use `process.env.PORT` when bootstrapping apps
- fix `BookService.update` filter syntax

## Testing
- `pnpm install --frozen-lockfile`
- `MONGODB_URI='mongodb://localhost:27017/test' pnpm test` *(fails: BookService dependency not resolved)*

------
https://chatgpt.com/codex/tasks/task_b_685587784af083208c591749d7cb823c